### PR TITLE
Fix cookie removal bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.26] - December 12, 2025
+
+### 🐛 Bug Fixes
+
+- session.server.ts bugfix for getToken method. Fixes session loose after server restart. Was deleting cache before checking validation.
+
 ## [0.2.25] - December 4, 2025
 
 ### 🐛 Bug Fixes
@@ -33,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🐛 Bug Fixes
 
 - mariadb now support colon notation in query method ie: `select data:color from json_test where data:contact.phone = ?`
-  0.2.22 bug fix which use dot notation which conflict with table alias 
+  0.2.22 bug fix which use dot notation which conflict with table alias
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dokuzbit/utils",
   "description": "Utility functions for web apps, both server and client.",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "author": "dokuzbit",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Conditionally remove cache in `getToken` to prevent premature deletion during token refresh.

The previous implementation unconditionally removed the cache at the start of the `catch` block in `getToken`. This caused the cache to be deleted even when a `TokenExpiredError` could be handled by a callback to refresh the token, leading to unnecessary cache invalidation. The change ensures the cache is only removed if the token is truly invalid or the refresh process fails.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed37d50e-f27c-4dee-b924-bc6cc5ec509a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed37d50e-f27c-4dee-b924-bc6cc5ec509a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `getToken` to clear cache only on true invalidation or non-expiration errors, plus version bump and changelog update.
> 
> - **Server (`server/session.server.ts`)**
>   - **`getToken` cache handling**: remove unconditional cache deletion; clear cache only when refresh fails, no callback is provided, or on non-expiration errors; retain cache when token is refreshed.
> - **Release**
>   - Bump version to `0.2.26` in `package.json`.
>   - Update `CHANGELOG.md` with bug fix notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ec2179982acdaf3872cd743cb01fdf60f6d6ec5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->